### PR TITLE
Flash messages are broken because the array key disagrees

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -366,12 +366,12 @@ class _Response extends StdClass {
             $params = $type;
             $type = 'info';
         }
-        if (!isset($_SESSION['__flash'])) {
-            $_SESSION['__flash'] = array($type => array());
-        } elseif (!isset($_SESSION['__flash'][$type])) {
-            $_SESSION['__flash'][$type] = array();
+        if (!isset($_SESSION['__flashes'])) {
+            $_SESSION['__flashes'] = array($type => array());
+        } elseif (!isset($_SESSION['__flashes'][$type])) {
+            $_SESSION['__flashes'][$type] = array();
         }
-        $_SESSION['__flash'][$type] = $this->markdown($msg, $params);
+        $_SESSION['__flashes'][$type] = $this->markdown($msg, $params);
     }
 
     //Support basic markdown syntax


### PR DESCRIPTION
As the subject notes, the array keys for flash messages seems to have gotten out of sync.
