### PR TITLE
Flashes should be a set of arrays, not a single item

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -371,7 +371,7 @@ class _Response extends StdClass {
         } elseif (!isset($_SESSION['__flashes'][$type])) {
             $_SESSION['__flashes'][$type] = array();
         }
-        $_SESSION['__flashes'][$type] = $this->markdown($msg, $params);
+        $_SESSION['__flashes'][$type][] = $this->markdown($msg, $params);
     }
 
     //Support basic markdown syntax


### PR DESCRIPTION
Right here:

```
$_SESSION['__flashes'][$type] = array();
```

The code clearly intends that you could have multiple $type of messages in the flash array, but then the array gets overwritten:

```
$_SESSION['__flashes'][$type][] = $this->markdown($msg, $params);
```

Simply fix.
