### PR TITLE
Changed fpassthru() to readfile() in $response->file() on line 412.

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -409,7 +409,7 @@ class _Response extends StdClass {
             $filename = basename($path);
         }
         header('Content-Disposition: attachment; filename="'.$filename.'"');
-        fpassthru($path);
+        readfile($path);
     }
 
     //Sends an object as json


### PR DESCRIPTION
Changed fpassthru($path) to readfile($path) on line 412 in $response->file() because fpassthru() expects a file handle instead of a string. Readfile() handles a string correctly.
# 

Hello Chris,

I've been using klein.php for a day or two, and I wanted to use the file sending functionality. But I couldn't get it to work because fpassthru() expects a file handle instead of a string. So I changed it to use readfile() instead.

If you want, I can also add some code to override the MIME type, because that would be handy as well. Let me know if you'd appreciate that and I'll send you a new pull request with that functionality.

Anyway, thanks for the great library!

Regards,
Berklee
