### PR TITLE
Here's the pull request for the MIME type.

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -399,15 +399,18 @@ class _Response extends StdClass {
     }
 
     //Sends a file
-    public function file($path, $filename = null) {
+    public function file($path, $filename = null, $mimetype = null) {
         $this->discard();
         $this->noCache();
         set_time_limit(1200);
-        header('Content-type: ' . finfo_file(finfo_open(FILEINFO_MIME_TYPE), $path));
-        header('Content-length: ' . filesize($path));
         if (null === $filename) {
             $filename = basename($path);
         }
+        if (null === $mimetype) {
+            $mimetype = finfo_file(finfo_open(FILEINFO_MIME_TYPE), $path)
+        }
+        header('Content-type: ' . $mimetype);
+        header('Content-length: ' . filesize($path));
         header('Content-Disposition: attachment; filename="'.$filename.'"');
         readfile($path);
     }


### PR DESCRIPTION
Added a $mimetype definition to $response->file(). You can specify the MIME type of the file you're sending, overriding PHP's interpretation of the file (handy for JavaScript and CSS files). Simply call $response->file("/path/to/file", "filename", "mime/type"). I use this for JavaScript files: $response->file("script/file.js", null, "application/javascript").
# 

I took the liberty to rearrange the $filename check, but adhered to your coding style. Hope that's ok.

Thanks again,
Berklee
