### PR TITLE
Store code when calling $response->code(), and let it return value

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -325,6 +325,7 @@ class _Response extends StdClass {
     protected $_errorCallbacks = array();
     protected $_layout = null;
     protected $_view = null;
+    protected $_code = 200;
 
     //Enable response chunking. See: http://bit.ly/hg3gHb
     public function chunk($str = null) {
@@ -430,9 +431,13 @@ class _Response extends StdClass {
     }
 
     //Sends a HTTP response code
-    public function code($code) {
-        $protocol = isset($_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0';
-        header("$protocol $code");
+    public function code($code = null) {
+        if(null !== $code) {
+            $this->_code = $code;
+            $protocol = isset($_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0';
+            header("$protocol $code");
+        }
+        return $this->_code;
     }
 
     //Redirects the request to another URL


### PR DESCRIPTION
This patch makes `$response->code()` a getter in addition to a setter.
