### PR TITLE
return the session value rather than its key

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -299,7 +299,7 @@ class _Request {
     //Gets a session variable associated with the request
     public function session($key, $default = null) {
         startSession();
-        return isset($_SESSION[$key]) ? $key : $default;
+        return isset($_SESSION[$key]) ? $_SESSION[$key] : $default;
     }
 
     //Gets the request IP address


### PR DESCRIPTION
fixes _Request->session which returned the given $key rather than it's associated value.
