### PR TITLE
Support for the X-HTTP-Method-Override header

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -60,6 +60,13 @@ function dispatch($uri = null, $req_method = null, array $params = null, $captur
     }
     if (null === $req_method) {
         $req_method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET';
+
+        //For legacy servers: override the HTTP method with the X-HTTP-Method-Override header
+        $headers = apache_request_headers();
+        if(isset($headers['X-HTTP-Method-Override']))
+        {
+            $req_method = $headers['X-HTTP-Method-Override'];
+        }
     }
 
     //Force request_order to be GP


### PR DESCRIPTION
I have implemented an internal single-page web app at my job. On the client side, it uses backbone.js (javascript MVC library). The client side code calls a Rest API that uses (of course!) klein.

One issue is that all requests send to our servers are routed through a proxy that refuses PUT and DELETE methods. To adress this, backbone.js uses the X-HTTP-Method-Override header. The X-HTTP-Method-Override header overrides the actual method, so that PUT and DELETE requests may be sent with the POST method.

Adding 5 lines of code was enough to support this mechanism. What do you think? 
