### PR TITLE
minor change

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -384,7 +384,7 @@ class _Response extends StdClass {
     }
 
     //Support basic markdown syntax
-    public function markdown($str, $args = null) {
+    public function markdown($str, $args = array()) {
         $args = func_get_args();
         $md = array(
             '/\[([^\]]++)\]\(([^\)]++)\)/' => '<a href="$2">$1</a>',


### PR DESCRIPTION
PHP errored in markdown function trying to treat the $args default value (null) as an array.
This change defaults $args to an empty array() rather than null.
