### PR TITLE
Make "match all" work with namespaces

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -22,7 +22,7 @@ function respond($method, $route = '*', $callback = null) {
 
     // empty route with namespace is a match-all
     if( $__namespace && ( null == $route || '*' == $route ) ) {
-        $route = '@' . $__namespace . '(/|$)';
+        $route = '@^' . $__namespace . '(/|$)';
     } else {
         $route = $__namespace . $route;
     }


### PR DESCRIPTION
Match-all is only supported in the top-level namespace, complicating the nesting of routes. This pull request enables the following syntax:

```
respond( function(){
    echo "Outer\n";
});

with( "/foo", function(){
    respond( function(){
        echo "Inner\n";
    });
});
```

Regex before: `^/foo$`
Regex after: `^/foo(/|$)`
