### PR TITLE
Fixed bug with combining 404 and catchall routes

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -180,7 +180,9 @@ function dispatch($uri = null, $req_method = null, array $params = null, $captur
             } catch (Exception $e) {
                 $response->error($e);
             }
-            $count_match && ++$matched;
+            if ($_route !== '*' && $_route !== null) {
+                $count_match && ++$matched;
+            }
         }
     }
     if (!$matched) {


### PR DESCRIPTION
Fixed bug where 404 route won't be triggered if a catchall route comes before it.
