### PR TITLE
Fix parsing of regex route within namespace

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -19,8 +19,31 @@ function respond($method, $route = '*', $callback = null) {
         $method = null;
     }
 
+    if( $__namespace && $route[0] === '@' || ( $route[0] === '!' && $route[1] === '@' ) ) {
+        if( $route[0] === '!' ) {
+            $negate = true;
+            $route = substr( $route, 2 );
+        } else {
+            $negate = false;
+            $route = substr( $route, 1 );
+        }
+
+        // regex anchored to front of string
+        if( $route[0] === '^' ) {
+            $route = substr( $route, 1 );
+        } else {
+            $route = '.*' . $route; 
+        }
+
+        if( $negate ) {
+            $route = '@^' . $__namespace . '(?!' . $route . ')';
+        } else {
+            $route = '@^' . $__namespace . $route;
+        }
+    }
+
     // empty route with namespace is a match-all
-    if( $__namespace && ( null == $route || '*' == $route ) ) {
+    elseif( $__namespace && ( null == $route || '*' === $route ) ) {
         $route = '@^' . $__namespace . '(/|$)';
     } else {
         $route = $__namespace . $route;


### PR DESCRIPTION
Modify parsing of regex routes within namespaces:
1. Prepend the namespace to all regexes
2. Interpret circumflex (`^`) anchor appropriately in relation to namespace
3. Ensure that negation only matches hits within the namespace

See #40 for original issue and test code.

Slightly wonky aspect of this: the prepending slash.

``` php
<?php

with( '/path', function(){
    respond( '@foo', $cb ); // matches /path/foo, /pathfoo, /pathfood, /path/hoofoot
    respond( '@^foo', $cb ); // matches /pathfoo, /pathfood
    respond( '@^/foo', $cb ); // matches /path/foo, /path/food
});
```
