### PR TITLE
Lazy services feature

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -197,35 +197,6 @@ function dispatch($uri = null, $req_method = null, array $params = null, $captur
     }
 }
 
-/**
- * Stores a $closure as a service callback under $key, or
- * if $closure is not provided, gets an instance of stored
- * service by $key. Its like a lazy registry $closure is
- * evalueted only once on first service request
- */
-function service($key, Closure $closure = null) {
-    static $services = array();
-    if (null !== $closure) {
-        // store a service
-        if (isset($services[$key])) {
-            throw new RuntimeException("Service is allready registered under name: {$key}, to avoid complications it cannot be overwritten");
-        }
-        $services[$key] = function() use ($closure) {
-            static $instance;
-            if (null === $instance) {
-                $instance = $closure();
-            }
-            return $instance;
-        };
-        return;
-    } elseif (isset($services[$key])) {
-        // get a service
-        return $services[$key]();
-    }
-    // invalid service key or closure argument
-    throw new InvalidArgumentException("There is no service registered under name: [$key]");
-}
-
 //Compiles a route string to a regular expression
 function compile_route($route) {
     if (preg_match_all('`(/|\.|)\[([^:\]]*+)(?::([^:\]]*+))?\](\?|)`', $route, $matches, PREG_SET_ORDER)) {
@@ -780,6 +751,23 @@ class _Validator {
 }
 
 class _App {
+    private $services = array();
+
+    /**
+     * Gets a service instance by its $name
+     */
+    public function __get($name) {
+        if (!isset($this->services[$name])) {
+            throw new InvalidArgumentException("There is no service registered under name: [$name]");
+        }
+        return $this->services[$name]();
+    }
+
+    /**
+     * Calls a method registered to application
+     * like: $app->method = function() {...};
+     * Can be invoked like $app->method();
+     */
     public function __call( $method, $args ) {
         if (!isset($this->$method) || !is_callable($this->$method)) {
             throw new ErrorException("Unknown method $method()");
@@ -790,5 +778,23 @@ class _App {
         } else {
             return call_user_func_array( $this->$method, $args );
         }
+    }
+
+    /**
+     * Stores a $closure as a service callback under $name.
+     * Its like a lazy registry, $closure is
+     * evalueted only once on first service request
+     */
+    public function register($name, Closure $closure) {
+        if (isset($this->services[$name])) {
+            throw new RuntimeException("Service is allready registered under name: {$name}, to avoid complications it cannot be overwritten");
+        }
+        $this->services[$name] = function() use ($closure) {
+            static $instance;
+            if (null === $instance) {
+                $instance = $closure();
+            }
+            return $instance;
+        };
     }
 }


### PR DESCRIPTION
Implements a lazy service registry. Registered services are evaluated only during the first request all following requests will get the same instance of the service.

Looking at the code I noticed that _App usage is very limited and may be not useful practically. Maybe it can be removed?
