### PR TITLE
Fixes to $response->json()

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ $response->
     flash($msg, $type = 'info', $params = array()   // Set a flash message
     file($path, $filename = null)                   // Send a file
     noCache()                                       // Tell the browser not to cache the response
-    json($object, $callback = null)                 // Send an object as JSON(p)
+    json($object, $jsonp_prefix = null)             // Send an object as JSON or JSONP by providing padding prefix
     markdown($str, $args, ...)                      // Return a string formatted with markdown
     code($code = null)                              // Return the HTTP response code, or send a new code
     redirect($url, $code = 302)                     // Redirect to the specified URL

--- a/klein.php
+++ b/klein.php
@@ -438,16 +438,17 @@ class _Response extends StdClass {
         readfile($path);
     }
 
-    //Sends an object as json
-    public function json($object, $callback = null) {
+    //Sends an object as json or jsonp by providing the padding prefix
+    public function json($object, $jsonp_prefix = null) {
         $this->discard();
         $this->noCache();
         set_time_limit(1200);
         $json = json_encode($object);
-        header('Content-Type: application/json');
-        if (null !== $callback) {
-            echo $callback($json);
+        if (null !== $jsonp_prefix) {
+            header('Content-Type: text/javascript'); // should ideally be application/json-p once adopted
+            echo "$jsonp_prefix($json);";
         } else {
+            header('Content-Type: application/json');
             echo $json;
         }
     }


### PR DESCRIPTION
Thank you for this awesome hardcore minimalist one size fits all page router, knap gedaan! 

Here is my small contribution to the amazing effort you've already done.
- Added the Content-Type: application/json to the $request->json() function to reflect the json content we are responding with.
- The quotes surrounding the $callback when doing the echo and passing a closure got php's knickers in a twist but  by removing them it now works perfectly when doing something like;

``` php
<?php
    $response->json($data, function ($json) {
      return "<pre>". $json ."</pre>";
    });
```

...not sure if this was the intended purpose or not?

PHP's complaint otherwise:
**Catchable fatal error:** Object of class Closure could not be converted to string in /[snip]/klein.php on line 474

Keep up the great work...
