### PR TITLE
Method Matching - 405 Error Handling

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -150,8 +150,12 @@ function dispatch($uri = null, $req_method = null, array $params = null, $captur
             $match = true;
 
         //Easily handle 404's
-        } elseif ($_route === '404' && !$matched) {
-            $callback($request, $response, $app, $matched);
+        } elseif ($_route === '404' && !$matched && count($methods_matched) <= 0) {
+            $callback($request, $response, $app, $matched, $methods_matched);
+            ++$matched;
+        //Easily handle 405's
+        } elseif ($_route === '405' && !$matched && count($methods_matched) > 0) {
+            $callback($request, $response, $app, $matched, $methods_matched);
             ++$matched;
 
         //@ is used to specify custom regex
@@ -219,11 +223,13 @@ function dispatch($uri = null, $req_method = null, array $params = null, $captur
              }
         }
     }
+
     if (!$matched && count($methods_matched) > 0) {
         $response->code(405);
     } elseif (!$matched) {
         $response->code(404);
     }
+
     if ($capture) {
         return ob_get_clean();
     } elseif ($response->chunked) {


### PR DESCRIPTION
## These are my proposed changes for issue #50

I followed your (@chriso) testing model to make sure I wasn't slowing down the router with any of the extra logic. The performance is still amazing, as usual.

Essentially, what this code does, is it keeps track of each **HTTP Method** that is found in any of the matching routes, and passes that data along with each closure.

It also defaults to sending a **405** HTTP code when it finds that 1 or more of the routers/responders COULD have matched, if it hadn't had been for using the wrong HTTP Method.

I made sure to enable a 405 route match, so that anyone using the library could override/change/etc the behavior of the router when a 405 occurs.

_Error Code Reference - http://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_Error_
