### PR TITLE
Fix Nginx HTTP Status Header

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -503,8 +503,17 @@ class _Response extends StdClass {
     public function code($code = null) {
         if(null !== $code) {
             $this->_code = $code;
-            $protocol = isset($_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0';
-            $this->header("$protocol $code");
+
+		  // Do we have the PHP 5.4 "http_response_code" function?
+		  if ( function_exists( 'http_response_code' ) ) {
+			  // Have PHP automatically create our HTTP Status header from our code
+			  http_response_code( $code );
+		  }
+		  else {
+			  // Manually create the HTTP Status header
+			  $protocol = isset($_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0';
+			  $this->header("$protocol $code");
+		  }
         }
         return $this->_code;
     }


### PR DESCRIPTION
Unlike Apache, Nginx doesn't automatically fill in the status message for a newly written HTTP Status header. This quick edit fixes this by using the new built-in PHP Status header function.

Here's a quick image, showing the _before_ and _after_ of my fix, as it effects the header:

![](http://new.tinygrab.com/3f00c7451031aeafc17075baa14e272d173b6a3a71.png)
_( Pay attention to the first line in each curl response)_
#### Now using new PHP 5.4 "http_response_code" function

This automatically creates the proper HTTP Status header (with status
code AND message), making it much more compatible with Nginx (since
nginx doesn't automatically grab the status message of Status headers)
