### PR TITLE
HTTP/1.1 - 405 Error Compliance

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -205,7 +205,7 @@ function dispatch($uri = null, $req_method = null, array $params = null, $captur
 
         if (isset($match) && $match ^ $negate) {
              // Keep track of possibly matched methods
-             $methods_matched[] = $method;
+             $methods_matched = array_merge( $methods_matched, (array) $method );
              $methods_matched = array_filter( $methods_matched );
              $methods_matched = array_unique( $methods_matched );
 


### PR DESCRIPTION
The **HTTP/1.1** Standard dictates that a **405** error **must** contain a header called **Allow**, that lists (comma and space delimited) the **allowed methods** of that particular endpoint.

This pull-request adds the appropriate header on a 405 error condition.

"An Allow header field MUST be present in a 405 (Method Not Allowed) response."

Reference: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.7
