### PR TITLE
Pass exceptions from our 404 and 405 routes

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -151,11 +151,21 @@ function dispatch($uri = null, $req_method = null, array $params = null, $captur
 
         //Easily handle 404's
         } elseif ($_route === '404' && !$matched && count($methods_matched) <= 0) {
-            $callback($request, $response, $app, $matched, $methods_matched);
+            try {
+                $callback($request, $response, $app, $matched, $methods_matched);
+            } catch (Exception $e) {
+                $response->error($e);
+            }
+
             ++$matched;
         //Easily handle 405's
         } elseif ($_route === '405' && !$matched && count($methods_matched) > 0) {
-            $callback($request, $response, $app, $matched, $methods_matched);
+            try {
+                $callback($request, $response, $app, $matched, $methods_matched);
+            } catch (Exception $e) {
+                $response->error($e);
+            }
+
             ++$matched;
 
         //@ is used to specify custom regex


### PR DESCRIPTION
The **404** and **405** route callbacks in the "dispatch" method weren't passing exceptions to the Klein error handler, making exceptions throw and handle in an unexpected manner.

A simple copy-paste from the normal callback call was all that was necessary for the proper functionality.
