### PR TITLE
Adding session getter to response object

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -653,6 +653,11 @@ class _Response extends StdClass {
         }
     }
 
+    public function getSession ($key, $default = null) {
+        startSession();
+        return isset($_SESSION[$key]) ?  htmlentities($_SESSION[$key], ENT_QUOTES) : $default;
+    }
+
     // Returns an escaped request paramater
     public function param($param, $default = null) {
         return isset($_REQUEST[$param]) ?  htmlentities($_REQUEST[$param], ENT_QUOTES) : $default;


### PR DESCRIPTION
Since param getter already exists why not session getter?
Needed this in few places so here it is.
