### PR TITLE
validateUri()

### DIFF
--- a/klein.php
+++ b/klein.php
@@ -374,6 +374,11 @@ class _Request {
         return new _Validator($this->param($param), $err);
     }
 
+    // Start a validator chain for the current URI
+    public function validateUri($err = null) {
+        return new _Validator($this->uri(), $err);
+    }
+
     // Gets a unique ID for the request
     public function id() {
         if (null === $this->_id) {


### PR DESCRIPTION
I just struggled with the following problem: I need to check whether the requested site requires a user to be logged in or whether it's public. As the `validate()` in conjunction with `isRegex()` seemed really handy, I tried it but soon found out, `validate()` only supports `param()` but not `uri()`... So I decided to add the function `validateUri()`. I hope that's ok with you and doesn't contradict klein.php's philosophy!

FYI, that's how I use it:

``` php
respond('*', function ($request, $response, $app) {
    if($request->validateUri(false)->isRegex('/(home|about)/') === false){
        global $signiu;
        $signiu->requiredState(true);
    }
});
```
