### PR TITLE
Fixed bug regarding routing and the query string

### DIFF
--- a/Klein/Klein.php
+++ b/Klein/Klein.php
@@ -352,7 +352,7 @@ class Klein
 
 
         // Grab some data from the request
-        $uri = $this->request->uri(true); // Strip the query string
+        $uri = $this->request->pathname();
         $req_method = $this->request->method();
 
         // Set up some variables for matching


### PR DESCRIPTION
Hi,

It seems like the router referred to old code `$this->request->uri(true)` for stripping the query string from the URI, I changed it to use the `pathname` method defined in the `Request` class.

Kind regards,

Fred Oranje
