### PR TITLE
Feature - Route callback handling

### DIFF
--- a/src/Klein/Klein.php
+++ b/src/Klein/Klein.php
@@ -412,7 +412,6 @@ class Klein
             // Grab the properties of the route handler
             $method = $route->getMethod();
             $path = $route->getPath();
-            $callback = $route->getCallback();
             $count_match = $route->getCountMatch();
 
             // Keep track of whether this specific request method was matched


### PR DESCRIPTION
This PR adds a more strict type-hint to the `handleRouteCallback()` method for a more strict way of overriding the protected API while providing the method with more data (the actual Route instance).

This also strengthens the dispatch loop's code by reducing the number of methods called per loop iteration.

Finally, this fixes some of the ambiguously titled variables by giving them more appropriate names
