### PR TITLE
Bugfix - Locked response exceptions silenced

### DIFF
--- a/src/Klein/Klein.php
+++ b/src/Klein/Klein.php
@@ -765,10 +765,13 @@ class Klein
             if ($returned instanceof AbstractResponse) {
                 $this->response = $returned;
             } else {
-                $this->response->append($returned);
+                // Otherwise, attempt to append the returned data
+                try {
+                    $this->response->append($returned);
+                } catch (LockedResponseException $e) {
+                    // Do nothing, since this is an automated behavior
+                }
             }
-        } catch (LockedResponseException $e) {
-            // Do nothing, since this is an automated behavior
         } catch (DispatchHaltedException $e) {
             throw $e;
         } catch (Exception $e) {


### PR DESCRIPTION
This PR fixes the `handleRouteCallback()` method, to only catch LockedResponseExceptions when the behavior is automatic.

Previosly, we were catching all that could have been thrown during the callback's execution. Bad.
