### PR TITLE
Set routes property to empty array instead of null

### DIFF
--- a/src/Klein/Klein.php
+++ b/src/Klein/Klein.php
@@ -103,7 +103,7 @@ class Klein
      * @var RouteCollection
      * @access protected
      */
-    protected $routes;
+    protected $routes = array();
 
     /**
      * The Route factory object responsible for creating Route instances


### PR DESCRIPTION
When running dispatch without any routes, iterating through the routes property throws an error. This pull request fixes that behaviour.
