### PR TITLE
allow routes callable to be array

### DIFF
--- a/src/Klein/Klein.php
+++ b/src/Klein/Klein.php
@@ -360,7 +360,11 @@ class Klein
         $this->route_factory->appendNamespace($namespace);
 
         if (is_callable($routes)) {
-            $routes($this);
+            if (is_string($routes)) {
+                $routes($this);
+            } else {
+                call_user_func($routes, $this);
+            }
         } else {
             require $routes;
         }


### PR DESCRIPTION
process it with call_user_func

In my case I am using Klein with custom Controllers initialized via Reflection class:

```
foreach(array('One', 'Two') as $controller) {
    $cls = ucfirst($controller."Controller");
    $rc = new ReflectionClass($cls);
    $klein->with("/$controller", array($rc, 'newInstance'));
}
```
