### PR TITLE
remove "create" from RESTful POST request

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $klein->respond('/[:name]', function ($request) {
 
 ```php
 $klein->respond('GET', '/posts', $callback);
-$klein->respond('POST', '/posts/create', $callback);
+$klein->respond('POST', '/posts', $callback);
 $klein->respond('PUT', '/posts/[i:id]', $callback);
 $klein->respond('DELETE', '/posts/[i:id]', $callback);
 $klein->respond('OPTIONS', null, $callback);


### PR DESCRIPTION
The /post/create URI is incorrect as the whole point of RESTful services is to not set a state:

GET    - Read
POST   - Create
PUT    - Update
DELETE - Delete
