### PR TITLE
Suggestion: creating a cookie object for both the request and response

### DIFF
--- a/src/Klein/Cookie.php
+++ b/src/Klein/Cookie.php
@@ -12,13 +12,13 @@
 namespace Klein;
 
 /**
- * ResponseCookie
+ * Cookie
  *
  * Class to represent an HTTP response cookie
  *
  * @package     Klein
  */
-class ResponseCookie
+class Cookie
 {
 
     /**


### PR DESCRIPTION
On top of the ability to create cookies with the `AbstractResponse::cookie()` method, it would be nice to be able to create `Cookie` objects and add them like so:

``` php
$myCookie = new Cookie();
$myCookie->setName('my_cookie');
$myCookie->setValue('my_value');

$response->addCookie($cookie);
```

This is just to open the discussion, as the commits don't do much yet.
