### PR TITLE
Rake my current created routes

### DIFF
--- a/src/Klein/Klein.php
+++ b/src/Klein/Klein.php
@@ -426,7 +426,7 @@ class Klein
      *
      * @return void|array
      */
-    public function rakeRoutes($print = true) 
+    public function rakeRoutes($print = true)
     {
         $routeNames = array();
         foreach ($this->routes as $route) {
@@ -439,9 +439,9 @@ class Klein
                 array_push($routeNames, '['.$method.'] '.$_route);
             }
         }
-        
-        if (!$print)
+        if (!$print) {
             return $routeNames;
+        }
     }
 
     /**


### PR DESCRIPTION
# What

I wanted to know all the routes i created in my project and i did not want to go through all the controllers i created holding the routes. So i added a function to print out the routes. Its a small thing, i just found it very helpful and maybe something even better can be done here to make this information rake more detailed and useful. Maybe even prettier printing. 
# How

Your project should have this structure

```
vendor/
etc/
     -> app.php
 index.php
 rake.php
 .htaccess #to force all urls through index.php
```

example my .htaccess is

```
Options -Indexes

DirectoryIndex index.php

RewriteEngine on
RewriteCond %{REQUEST_FILENAME} !-f
RewriteCond %{REQUEST_FILENAME} !-d
RewriteCond $1 !^(index\.php|assets)
RewriteRule . index.php [L]
```
- Inside `etc/app.php` have all your code with routes e.t.c **except** for `$klein->dispatch();`
- Inside `index.php`, include require `/etc/app.php` and call `$klein->dispatch();`
- Inside `rake.php`, include require `/etc/app.php` and call `$klein->rakeRoutes();`
