### PR TITLE
Rewind array after foreach by reference in DataCollectionTest

### DIFF
--- a/tests/Klein/Tests/DataCollection/DataCollectionTest.php
+++ b/tests/Klein/Tests/DataCollection/DataCollectionTest.php
@@ -51,6 +51,7 @@ class DataCollectionTest extends AbstractKleinTest
                 $this->prepareSampleData($data);
             }
         }
+        reset($sample_data);
     }
 
     /**

--- a/tests/Klein/Tests/DataCollection/HeaderDataCollectionTest.php
+++ b/tests/Klein/Tests/DataCollection/HeaderDataCollectionTest.php
@@ -50,6 +50,7 @@ class HeaderDataCollectionTest extends AbstractKleinTest
                 $this->prepareSampleData($data);
             }
         }
+        reset($sample_data);
     }
 
     /**


### PR DESCRIPTION
HHVM's behaviour on foreach by reference might differ from php. This is happening here.
HHVM will incremend the internal array pointer while php doesn't. This causes test to fail on hhvm

See https://github.com/facebook/hhvm/blob/master/hphp/doc/inconsistencies#L29-L35

This increases klein on HHVM from 97.66% to 100% o/
