### PR TITLE
Update PHPUnit to 4.1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
       "php": ">=5.3.0"
    },
    "require-dev": {
-      "phpunit/phpunit": "3.7.x",
-      "phpunit/php-code-coverage": "1.2.x",
+      "phpunit/phpunit": "4.1.x",
+      "phpunit/php-code-coverage": "2.x",
       "squizlabs/php_codesniffer": "1.4.8"
    },
    "autoload": {


### PR DESCRIPTION
PHPUnit added HHVM support in 4.x
This also needed an update to php-code-coverage

This brings HHVM to 100% passrate in master
