### PR TITLE
Fixed "Indirect modification of overloaded property" issue.

### DIFF
--- a/src/Klein/Request.php
+++ b/src/Klein/Request.php
@@ -326,7 +326,7 @@ class Request
      * @param string $param     The name of the parameter
      * @return string
      */
-    public function __get($param)
+    public function &__get($param)
     {
         return $this->param($param);
     }


### PR DESCRIPTION
Hi,

My Bugsnag was flooded with this error message from Klein. This is the line it is happening:

```
array_walk( (array) $req->widgets, function($val, $key) use ($app) {
    $app->widgetStatsDB->addImpression($val);
});
```

The whole error message is:

`Indirect modification of overloaded property Klein\Request::$widgets has no effect`

Not sure if this one creates more issues but that solved my issue. Perhabs it may be configured to do isset instead of passing by reference.

Can be a bug report too.
