### PR TITLE
Add PHP7 to Travis and Fix Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.4
   - 5.5
   - hhvm
+  - 7
 
 before_script:
   - composer install --prefer-dist --dev
@@ -15,4 +16,6 @@ script:
 matrix:
   allow_failures:
     - php: hhvm
+    - php: 7
+
   fast_finish: true

--- a/tests/Klein/Tests/Mocks/TestClass.php
+++ b/tests/Klein/Tests/Mocks/TestClass.php
@@ -14,7 +14,7 @@ namespace Klein\Tests\Mocks;
 class TestClass
 {
 
-    public static function get($r, $r, $a)
+    public static function get($r, $re, $a)
     {
         echo 'ok';
     }

--- a/tests/Klein/Tests/RoutingTest.php
+++ b/tests/Klein/Tests/RoutingTest.php
@@ -113,19 +113,19 @@ class RoutingTest extends AbstractKleinTest
 
         $this->klein_app->respond(
             '/',
-            function ($r, $r, $s, $a) {
+            function ($r, $re, $s, $a) {
                 $a->state = 'a';
             }
         );
         $this->klein_app->respond(
             '/',
-            function ($r, $r, $s, $a) {
+            function ($r, $re, $s, $a) {
                 $a->state .= 'b';
             }
         );
         $this->klein_app->respond(
             '/',
-            function ($r, $r, $s, $a) {
+            function ($r, $re, $s, $a) {
                 print $a->state;
             }
         );


### PR DESCRIPTION
Fixing a few tests that PHP7 didn't like, and added PHP7 as a test target, which is allowed to fail.
