### PR TITLE
Flexible routing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-   "name": "coffeetalkh/klein",
+   "name": "klein/klein",
    "description": "A lightning fast router for PHP",
    "keywords": ["router", "routing", "sinatra", "boilerplate"],
    "homepage": "https://github.com/chriso/klein.php",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-   "name": "klein/klein",
+   "name": "coffeetalkh/klein",
    "description": "A lightning fast router for PHP",
    "keywords": ["router", "routing", "sinatra", "boilerplate"],
    "homepage": "https://github.com/chriso/klein.php",

--- a/src/Klein/Klein.php
+++ b/src/Klein/Klein.php
@@ -392,6 +392,46 @@ class Klein
     }
 
     /**
+ * Collect a set of routes under a common namespace
+ *
+ * The routes may be passed in as either a callable (which holds the route definitions),
+ * or as a string of a filename, of which to "include" under the Klein router scope with
+ * flexible ability to split route from controller name.
+ *
+ * <code>
+ * $router = new Klein();
+ *
+ * $router->withFlex( 'user', '/users', function($router) {
+ *     $router->respond( '/', function() {
+ *         // do something interesting
+ *     });
+ *     $router->respond( '/[i:id]', function() {
+ *         // do something different
+ *     });
+ * });
+ *
+ * $router->withFlex( 'car', '/cars', __DIR__ . '/routes/cars.php');
+ * </code>
+ *
+ * @param $class 					The Controller class name
+ * @param string $namespace         The namespace under which to collect the routes
+ * @param callable|string $routes   The defined routes callable or filename to collect under the namespace
+ * @return void
+ */
+public function withFlex( $class, $namespace, $routes ) {
+
+  if ( class_exists( $class ) ) {
+
+    $this->app->controller = new $class;
+
+  }
+
+  return $this->with( $namespace, $routes );
+
+
+}
+
+    /**
      * Dispatch the request to the appropriate route(s)
      *
      * Dispatch with optionally injected dependencies

--- a/src/Klein/Klein.php
+++ b/src/Klein/Klein.php
@@ -392,44 +392,68 @@ class Klein
     }
 
     /**
- * Collect a set of routes under a common namespace
- *
- * The routes may be passed in as either a callable (which holds the route definitions),
- * or as a string of a filename, of which to "include" under the Klein router scope with
- * flexible ability to split route from controller name.
- *
- * <code>
- * $router = new Klein();
- *
- * $router->withFlex( 'user', '/users', function($router) {
- *     $router->respond( '/', function() {
- *         // do something interesting
- *     });
- *     $router->respond( '/[i:id]', function() {
- *         // do something different
- *     });
- * });
- *
- * $router->withFlex( 'car', '/cars', __DIR__ . '/routes/cars.php');
- * </code>
- *
- * @param $class 					The Controller class name
- * @param string $namespace         The namespace under which to collect the routes
- * @param callable|string $routes   The defined routes callable or filename to collect under the namespace
- * @return void
- */
-public function withFlex( $class, $namespace, $routes ) {
+     * Collect a set of routes under a common namespace
+     *
+     * The routes may be passed in as either a callable (which holds the route definitions),
+     * or as a string of a filename, of which to "include" under the Klein router scope with
+     * flexible ability to split route from controller name.
+     *
+     * <code>
+     * $router = new Klein();
+     *
+     * $router->withFlex( 'user', '/users', function($router) {
+     *     $router->respond( '/', function() {
+     *         // do something interesting
+     *     });
+     *     $router->respond( '/[i:id]', function() {
+     *         // do something different
+     *     });
+     * });
+     *
+     *  $router->withFlex( array( 'UserController', 'TestController' ), '/home', function($router) {
+     *     $router->respond( '/users', function() {
+     *         return $app->UserController->index();
+     *     });
+     *     $router->respond( '/tests', function() {
+     *         return $app->TestController->index();
+     *     });
+     * });
+     *
+     * $router->withFlex( 'car', '/cars', __DIR__ . '/routes/cars.php');
+     * </code>
+     *
+     * @param $class 					The Controller class name
+     * @param string $namespace         The namespace under which to collect the routes
+     * @param callable|string $routes   The defined routes callable or filename to collect under the namespace
+     * @return void
+     */
+    public function withFlex( $class, $namespace, $routes ) {
 
-  if ( class_exists( $class ) ) {
+    	if ( is_array( $class ) ) {
 
-    $this->app->controller = new $class;
+    		foreach ( $class as $key => $c ) {
 
-  }
+    			if ( class_exists( $c ) ) {
 
-  return $this->with( $namespace, $routes );
+    				$this->app->{$c} = new $c;
 
+    			}
 
-}
+    		}
+
+    	} else {
+
+    		if ( class_exists( $class ) ) {
+
+    			$this->app->{$class} = new $class;
+
+    		}
+
+    	}
+
+    	return $this->with( $namespace, $routes );
+      
+    }
 
     /**
      * Dispatch the request to the appropriate route(s)


### PR DESCRIPTION
Sometimes i need to create a route which the route name is not related to controller name, i created the `withFlex()` method to handle this action, is there another way to do this?

```
$klein->withFlex( 'TestController', '/test-route', function () use ($klein) {

    $klein->respond('GET', '/?', function ($request, $response, $service, $app) {

        return $app->controller->index();

    });

    $klein->respond( 'GET', '/[:id]', function ($request, $response, $service, $app)  {

        return $app->controller->show( $request->id( false ) );

    });

});
```
