### PR TITLE
Small phpdoc fix in Klein\Request

### DIFF
--- a/src/Klein/Request.php
+++ b/src/Klein/Request.php
@@ -290,7 +290,7 @@ class Request
      *
      * @param string $key       The name of the parameter to return
      * @param mixed $default    The default value of the parameter if it contains no value
-     * @return string
+     * @return string|array|null
      */
     public function param($key, $default = null)
     {

--- a/src/Klein/Request.php
+++ b/src/Klein/Request.php
@@ -290,7 +290,7 @@ class Request
      *
      * @param string $key       The name of the parameter to return
      * @param mixed $default    The default value of the parameter if it contains no value
-     * @return string|array|null
+     * @return mixed
      */
     public function param($key, $default = null)
     {

--- a/src/Klein/Request.php
+++ b/src/Klein/Request.php
@@ -324,7 +324,7 @@ class Request
      * while treating it as an instance property
      *
      * @param string $param     The name of the parameter
-     * @return string
+     * @return mixed
      */
     public function __get($param)
     {


### PR DESCRIPTION
Klein\Request::param may return null, if there is no key and default is null.

Also it may return array, if html form contains inputs like is like:

``` html
<input type="hidden" name="id[]" value="1">
<input type="hidden" name="id[]" value="2">
<input type="hidden" name="id[]" value="3">
```

``` php
<?php
// $ids will contain array of ids
$ids = $request->param('id');
```
