### PR TITLE
bugfix, file download doesn't work while running on FPM

### DIFF
--- a/src/Klein/AbstractResponse.php
+++ b/src/Klein/AbstractResponse.php
@@ -391,7 +391,7 @@ abstract class AbstractResponse
      * @throws ResponseAlreadySentException If the response has already been sent
      * @return AbstractResponse
      */
-    public function send($override = false)
+    public function send($override = false, $noMoreData = true)
     {
         if ($this->sent && !$override) {
             throw new ResponseAlreadySentException('Response has already been sent');
@@ -408,7 +408,7 @@ abstract class AbstractResponse
         $this->sent = true;
 
         // If there running FPM, tell the process manager to finish the server request/response handling
-        if (function_exists('fastcgi_finish_request')) {
+        if (function_exists('fastcgi_finish_request') && $noMoreData) {
             fastcgi_finish_request();
         }
 

--- a/src/Klein/Response.php
+++ b/src/Klein/Response.php
@@ -12,7 +12,7 @@
 namespace Klein;
 
 /**
- * Response
+ * Response 
  */
 class Response extends AbstractResponse
 {
@@ -92,7 +92,7 @@ class Response extends AbstractResponse
         $this->header('Content-length', filesize($path));
         $this->header('Content-Disposition', 'attachment; filename="'.$filename.'"');
 
-        $this->send();
+        $this->send(false, false);
 
         readfile($path);
 


### PR DESCRIPTION
file download doesn't work while running on FPM, cause by output buffer have been closed by function `fastcgi_finish_request();`
