### PR TITLE
Bugfix: File Response Problems

### DIFF
--- a/src/Klein/Response.php
+++ b/src/Klein/Response.php
@@ -11,6 +11,8 @@
 
 namespace Klein;
 
+use RuntimeException;
+
 /**
  * Response
  */
@@ -75,6 +77,7 @@ class Response extends AbstractResponse
      * @param string $filename  The file's name
      * @param string $mimetype  The MIME type of the file
      * @return Response
+     * @throws RuntimeException Thrown if the file could not be read
      */
     public function file($path, $filename = null, $mimetype = null)
     {
@@ -92,7 +95,11 @@ class Response extends AbstractResponse
         $this->header('Content-length', filesize($path));
         $this->header('Content-Disposition', 'attachment; filename="'.$filename.'"');
 
-        readfile($path);
+        $bytes_read = readfile($path);
+
+        if (false === $bytes_read) {
+            throw new RuntimeException('The file could not be read');
+        }
 
         $this->send();
 

--- a/src/Klein/Response.php
+++ b/src/Klein/Response.php
@@ -92,9 +92,9 @@ class Response extends AbstractResponse
         $this->header('Content-length', filesize($path));
         $this->header('Content-Disposition', 'attachment; filename="'.$filename.'"');
 
-        $this->send();
-
         readfile($path);
+
+        $this->send();
 
         return $this;
     }


### PR DESCRIPTION
This was a fun one to debug. I've been using [`Response::file()`](https://github.com/klein/klein.php/blob/eb80e09d222aa1a6ca2a0ea48b386433d8c4d169/src/Klein/Response.php#L79) to try to return a file. In this case, I've been using both `application/zip` and `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` `Content-Type` headers.

When calling this method, the response would hang until the connection timed out, even thought the correctly formatted file was present in the file system of the server.

It turned out that the issue was caused by the call to [`AbstractResponse::send()` within `Response::file()`](https://github.com/klein/klein.php/blob/eb80e09d222aa1a6ca2a0ea48b386433d8c4d169/src/Klein/Response.php#L95), due to the behavior of the call to [`fastcgi_finish_request` from `AbstractResponse::send()`](https://github.com/klein/klein.php/blob/eb80e09d222aa1a6ca2a0ea48b386433d8c4d169/src/Klein/AbstractResponse.php#L412). It turns out that finishing the request caused the `readfile()` call to hang, moving the `fastcgi_finish_request` logic into the `Response::file()` method fixed the issue.

I also added a conditional to the `Response::file()` method to not send the `Content-Length` header when the `Transfer-Encoding` header is set to `chunked`, this is in order to properly comply with [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4).

I couldn't come up with an appropriate unit test for this fix, but I'm open to suggestions. I've thoroughly tested this with integration tests and various other debugging strategies.

