### PR TITLE
Chore - v2.1.1 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Header key normalization is now customizable
 - Internal callback data-structures were moved from arrays to more appropriate SplQueue and SplStack instances, providing performance and memory footprint improvements
 - The PHPUnit version used for tests has been updated for HHVM compatibility
+- PHP 7.0 and HHVM compatibility!
 
 ### Bug fixes
 
@@ -18,6 +19,8 @@
 - The `file()` method in the `Response` class has been updated to fix an issue found when run under PHP-FPM
 - The `file()` method in the `Response` class will no longer send the `Content-Length` header when the response has been chunked, to comply with the HTTP requirements defined in RFC 2616
 - References to the old https://github.com/chriso/klein.php repository URL have been updated to the new repository URL home of Klein: https://github.com/klein/klein.php
+- Tests were updated to pass under an expanded number of PHP runtime versions and configurations
+- A potential output buffer stack miss-handling in the dispatch process has been fixed
 
 
 ## 2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # CHANGELOG
 
+
+## 2.1.1
+
+### Features
+
+- Header keys are now normalized, by default, to their canonical MIME format for consistency
+- Header key normalization is now customizable
+- Internal callback data-structures were moved from arrays to more appropriate SplQueue and SplStack instances, providing performance and memory footprint improvements
+- The PHPUnit version used for tests has been updated for HHVM compatibility
+
+### Bug fixes
+
+- A few internal property/attribute names have been updated for consistency
+- An iteration bug effecting tests run under certain HHVM runtime versions has been fixed
+- The README document has been updated to fix a few errors
+- The `file()` method in the `Response` class has been updated to fix an issue found when run under PHP-FPM
+- The `file()` method in the `Response` class will no longer send the `Content-Length` header when the response has been chunked, to comply with the HTTP requirements defined in RFC 2616
+- References to the old https://github.com/chriso/klein.php repository URL have been updated to the new repository URL home of Klein: https://github.com/klein/klein.php
+
+
 ## 2.1.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Klein.php
 
-[![Build Status](https://travis-ci.org/chriso/klein.php.png?branch=master)](https://travis-ci.org/chriso/klein.php)
+[![Build Status](https://travis-ci.org/klein/klein.php.png?branch=master)](https://travis-ci.org/klein/klein.php)
 
 **klein.php** is a fast & flexible router for PHP 5.3+
 
@@ -420,7 +420,7 @@ See the [contributing guide](CONTRIBUTING.md) for more info
 
 ## More information
 
-See the [wiki](https://github.com/chriso/klein.php/wiki) for more information
+See the [wiki](https://github.com/klein/klein.php/wiki) for more information
 
 ## Contributors
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,21 @@
 # Klein Upgrade Guide
 
+
+## 2.1.0 to 2.1.1
+
+### Deprecations
+
+- The `HeaderDataCollection::normalizeName()` method has been deprecated in favor of using new normalization options (via constant switches) and other more specific methods on the same class
+
+### Interface Changes
+
+- Three of the Klein internal callback attributes have changed both name and data structure. These attributes are protected, so the effect will only be felt by users that have extended and/or overwritten Klein's internal behaviors. The following changes were made:
+    - `Klein#errorCallbacks` was renamed to `Klein#error_callbacks` and it's array data-structure was changed to use an `SplStack`
+    - `Klein#httpErrorCallbacks` was renamed to `Klein#http_error_callbacks` and it's array data-structure was changed to use an `SplStack`
+    - `Klein#afterFilterCallbacks` was renamed to `Klein#after_filter_callbacks` and it's array data-structure was changed to use an `SplQueue`
+- `Validator#defaultAdded` was renamed to `Validator#default_added`
+
+
 ## 2.0.x to 2.1.0
 
 ### Deprecations

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
    "name": "klein/klein",
    "description": "A lightning fast router for PHP",
    "keywords": ["router", "routing", "sinatra", "boilerplate"],
-   "homepage": "https://github.com/chriso/klein.php",
+   "homepage": "https://github.com/klein/klein.php",
    "license": "MIT",
    "authors": [
       {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
       {
          "name": "Trevor Suarez",
          "email": "rican7@gmail.com",
-         "homepage": "http://about.me/tnsuarez",
+         "homepage": "https://trevorsuarez.com/",
          "role": "Contributor/Developer"
       }
    ],

--- a/src/Klein/AbstractResponse.php
+++ b/src/Klein/AbstractResponse.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 
@@ -428,7 +428,7 @@ abstract class AbstractResponse
     /**
      * Enable response chunking
      *
-     * @link https://github.com/chriso/klein.php/wiki/Response-Chunking
+     * @link https://github.com/klein/klein.php/wiki/Response-Chunking
      * @link http://bit.ly/hg3gHb
      * @return AbstractResponse
      */

--- a/src/Klein/AbstractRouteFactory.php
+++ b/src/Klein/AbstractRouteFactory.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/App.php
+++ b/src/Klein/App.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/DataCollection/DataCollection.php
+++ b/src/Klein/DataCollection/DataCollection.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/DataCollection/HeaderDataCollection.php
+++ b/src/Klein/DataCollection/HeaderDataCollection.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/DataCollection/ResponseCookieDataCollection.php
+++ b/src/Klein/DataCollection/ResponseCookieDataCollection.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/DataCollection/RouteCollection.php
+++ b/src/Klein/DataCollection/RouteCollection.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/DataCollection/ServerDataCollection.php
+++ b/src/Klein/DataCollection/ServerDataCollection.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Exceptions/DispatchHaltedException.php
+++ b/src/Klein/Exceptions/DispatchHaltedException.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Exceptions/DuplicateServiceException.php
+++ b/src/Klein/Exceptions/DuplicateServiceException.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Exceptions/HttpException.php
+++ b/src/Klein/Exceptions/HttpException.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Exceptions/HttpExceptionInterface.php
+++ b/src/Klein/Exceptions/HttpExceptionInterface.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Exceptions/KleinExceptionInterface.php
+++ b/src/Klein/Exceptions/KleinExceptionInterface.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Exceptions/LockedResponseException.php
+++ b/src/Klein/Exceptions/LockedResponseException.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Exceptions/RegularExpressionCompilationException.php
+++ b/src/Klein/Exceptions/RegularExpressionCompilationException.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Exceptions/ResponseAlreadySentException.php
+++ b/src/Klein/Exceptions/ResponseAlreadySentException.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Exceptions/RoutePathCompilationException.php
+++ b/src/Klein/Exceptions/RoutePathCompilationException.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Exceptions/UnhandledException.php
+++ b/src/Klein/Exceptions/UnhandledException.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Exceptions/UnknownServiceException.php
+++ b/src/Klein/Exceptions/UnknownServiceException.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Exceptions/ValidationException.php
+++ b/src/Klein/Exceptions/ValidationException.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/HttpStatus.php
+++ b/src/Klein/HttpStatus.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Klein.php
+++ b/src/Klein/Klein.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 
@@ -575,7 +575,7 @@ class Klein
                              * @link http://www.faqs.org/rfcs/rfc3986
                              *
                              * Decode here AFTER matching as per @chriso's suggestion
-                             * @link https://github.com/chriso/klein.php/issues/117#issuecomment-21093915
+                             * @link https://github.com/klein/klein.php/issues/117#issuecomment-21093915
                              */
                             $params = array_map('rawurldecode', $params);
 

--- a/src/Klein/Request.php
+++ b/src/Klein/Request.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Response.php
+++ b/src/Klein/Response.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 
@@ -27,7 +27,7 @@ class Response extends AbstractResponse
     /**
      * Enable response chunking
      *
-     * @link https://github.com/chriso/klein.php/wiki/Response-Chunking
+     * @link https://github.com/klein/klein.php/wiki/Response-Chunking
      * @link http://bit.ly/hg3gHb
      * @param string $str   An optional string to send as a response "chunk"
      * @return Response

--- a/src/Klein/ResponseCookie.php
+++ b/src/Klein/ResponseCookie.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Route.php
+++ b/src/Klein/Route.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/RouteFactory.php
+++ b/src/Klein/RouteFactory.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/ServiceProvider.php
+++ b/src/Klein/ServiceProvider.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/src/Klein/Validator.php
+++ b/src/Klein/Validator.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/AbstractKleinTest.php
+++ b/tests/Klein/Tests/AbstractKleinTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/AbstractRouteFactoryTest.php
+++ b/tests/Klein/Tests/AbstractRouteFactoryTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/AppTest.php
+++ b/tests/Klein/Tests/AppTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/DataCollection/DataCollectionTest.php
+++ b/tests/Klein/Tests/DataCollection/DataCollectionTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/DataCollection/HeaderDataCollectionTest.php
+++ b/tests/Klein/Tests/DataCollection/HeaderDataCollectionTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/DataCollection/ResponseCookieDataCollectionTest.php
+++ b/tests/Klein/Tests/DataCollection/ResponseCookieDataCollectionTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/DataCollection/RouteCollectionTest.php
+++ b/tests/Klein/Tests/DataCollection/RouteCollectionTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/DataCollection/ServerDataCollectionTest.php
+++ b/tests/Klein/Tests/DataCollection/ServerDataCollectionTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/HttpStatusTest.php
+++ b/tests/Klein/Tests/HttpStatusTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/KleinTest.php
+++ b/tests/Klein/Tests/KleinTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/Mocks/MockRequestFactory.php
+++ b/tests/Klein/Tests/Mocks/MockRequestFactory.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/Mocks/TestClass.php
+++ b/tests/Klein/Tests/Mocks/TestClass.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/RequestTest.php
+++ b/tests/Klein/Tests/RequestTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/ResponseCookieTest.php
+++ b/tests/Klein/Tests/ResponseCookieTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/ResponseTest.php
+++ b/tests/Klein/Tests/ResponseTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/RouteFactoryTest.php
+++ b/tests/Klein/Tests/RouteFactoryTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/RouteTest.php
+++ b/tests/Klein/Tests/RouteTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/RoutingTest.php
+++ b/tests/Klein/Tests/RoutingTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/ServiceProviderTest.php
+++ b/tests/Klein/Tests/ServiceProviderTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/Klein/Tests/ValidationsTest.php
+++ b/tests/Klein/Tests/ValidationsTest.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 

--- a/tests/functions-bootstrap.php
+++ b/tests/functions-bootstrap.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 


### PR DESCRIPTION
It's been a while since we've released and there's been a nagging bug with Klein running under HHVM and PHP-FPM (under some conditions), so time to release a quick patch version!

This PR simply preps for the release by updating the necessary documentation and updating references to the repository since the URL has changed from https://github.com/chriso/klein.php to https://github.com/klein/klein.php.

Fingers crossed! 🤞