### PR TITLE
Bugfix - Expected output unit test stability

### DIFF
--- a/tests/Klein/Tests/RoutingTest.php
+++ b/tests/Klein/Tests/RoutingTest.php
@@ -586,12 +586,14 @@ class RoutingTest extends AbstractKleinTest
 
     public function testParamsIntegerSuccess()
     {
-        $this->expectOutputString("string(3) \"987\"\n");
+        $this->expectOutputString("string(3) \"987\"");
 
         $this->klein_app->respond(
             '/[i:age]',
             function ($request) {
-                var_dump($request->param('age'));
+                $age = $request->param('age');
+
+                printf('%s(%d) "%s"', gettype($age), strlen($age), $age);
             }
         );
 
@@ -615,7 +617,7 @@ class RoutingTest extends AbstractKleinTest
         $this->klein_app->respond(
             '/[i:age]',
             function ($request) {
-                var_dump($request->param('age'));
+                echo $request->param('age');
             }
         );
 

--- a/tests/Klein/Tests/ValidationsTest.php
+++ b/tests/Klein/Tests/ValidationsTest.php
@@ -805,10 +805,7 @@ class ValidationsTest extends AbstractKleinTest
 
                 foreach ($args as $arg) {
                     if (null !== $previous) {
-                        if ((bool) $arg != (bool) $previous) {
-                            echo 'nope';
-                            var_dump($arg, $previous);
-                            var_dump((bool) $arg, (bool) $previous);
+                        if ((bool) $arg !== (bool) $previous) {
                             return false;
                         }
                     } else {


### PR DESCRIPTION
This PR fixes a bug found when running tests under certain PHP runtime versions and/or configurations.

It also removes some debug code that shouldn't have ever been committed and strengthens an equality check. Sooo, basically just some drive-by cleanup while fixing a problem. 😛 