### PR TITLE
Bugfix - PHPUnit upgrade and output buffer fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
       "php": ">=5.3.0"
    },
    "require-dev": {
-      "phpunit/phpunit": "4.1.x",
-      "phpunit/php-code-coverage": "2.x",
+      "phpunit/phpunit": "^4.8",
+      "phpunit/php-code-coverage": "^2.2",
       "squizlabs/php_codesniffer": "1.4.8"
    },
    "autoload": {

--- a/src/Klein/Klein.php
+++ b/src/Klein/Klein.php
@@ -158,6 +158,13 @@ class Klein
      */
     protected $after_filter_callbacks;
 
+    /**
+     * The output buffer level used by the dispatch process
+     *
+     * @type int
+     */
+    private $output_buffer_level;
+
 
     /**
      * Route objects
@@ -431,7 +438,9 @@ class Klein
         $params = array();
         $apc = function_exists('apc_fetch');
 
+        // Start output buffering
         ob_start();
+        $this->output_buffer_level = ob_get_level();
 
         try {
             foreach ($this->routes as $route) {
@@ -644,31 +653,29 @@ class Klein
                 switch($capture) {
                     case self::DISPATCH_CAPTURE_AND_RETURN:
                         $buffed_content = null;
-                        if (ob_get_level()) {
+                        while (ob_get_level() >= $this->output_buffer_level) {
                             $buffed_content = ob_get_clean();
                         }
                         return $buffed_content;
                         break;
                     case self::DISPATCH_CAPTURE_AND_REPLACE:
-                        if (ob_get_level()) {
+                        while (ob_get_level() >= $this->output_buffer_level) {
                             $this->response->body(ob_get_clean());
                         }
                         break;
                     case self::DISPATCH_CAPTURE_AND_PREPEND:
-                        if (ob_get_level()) {
+                        while (ob_get_level() >= $this->output_buffer_level) {
                             $this->response->prepend(ob_get_clean());
                         }
                         break;
                     case self::DISPATCH_CAPTURE_AND_APPEND:
-                        if (ob_get_level()) {
+                        while (ob_get_level() >= $this->output_buffer_level) {
                             $this->response->append(ob_get_clean());
                         }
                         break;
-                    case self::DISPATCH_NO_CAPTURE:
                     default:
-                        if (ob_get_level()) {
-                            ob_end_flush();
-                        }
+                        // If not a handled capture strategy, default to no capture
+                        $capture = self::DISPATCH_NO_CAPTURE;
                 }
             }
 
@@ -677,8 +684,12 @@ class Klein
                 // HEAD requests shouldn't return a body
                 $this->response->body('');
 
-                if (ob_get_level()) {
-                    ob_clean();
+                while (ob_get_level() >= $this->output_buffer_level) {
+                    ob_end_clean();
+                }
+            } elseif (self::DISPATCH_NO_CAPTURE === $capture) {
+                while (ob_get_level() >= $this->output_buffer_level) {
+                    ob_end_flush();
                 }
             }
         } catch (LockedResponseException $e) {
@@ -928,6 +939,11 @@ class Klein
             }
         } else {
             $this->response->code(500);
+
+            while (ob_get_level() >= $this->output_buffer_level) {
+                ob_end_clean();
+            }
+
             throw new UnhandledException($msg, $err->getCode(), $err);
         }
 


### PR DESCRIPTION
This PR updates PHPUnit to the highest stable version that we can use given our PHP runtime version constraints.

During the upgrade, thanks to PHPUnit's new "risky" test detection, I noticed a few problematic areas regarding the output buffer handling in Klein. I've cleaned them up and fixed a potential miss-handling of output buffer stacking.

Win win. 😃 