### PR TITLE
Chore - Travis-CI PHP versions and enhanced configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: php
 php:
   - 5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
   fast_finish: true
 
 before_script:
-  - composer install --prefer-dist --dev
+  - composer install --prefer-dist
 
 script:
   - composer validate

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,17 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
+  - nightly
   - hhvm
+
+matrix:
+  allow_failures:
+    - php: 7.0
+    - php: nightly
+    - php: hhvm
+  fast_finish: true
 
 before_script:
   - composer install --prefer-dist --dev
@@ -11,8 +21,3 @@ before_script:
 script:
   - ./vendor/bin/phpunit
   - ./vendor/bin/phpcs --standard=PSR2 --encoding=utf-8 -p src/ tests/
-
-matrix:
-  allow_failures:
-    - php: hhvm
-  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ before_script:
   - composer install --prefer-dist --dev
 
 script:
+  - composer validate
   - ./vendor/bin/phpunit
   - ./vendor/bin/phpcs --standard=PSR2 --encoding=utf-8 -p src/ tests/


### PR DESCRIPTION
This PR simply updates our Travis-CI configuration to test on newer PHP versions (5.6, 7.0, and the nightly), while also enabling our Travis-CI configuration to use [the new container-based infrastructure](https://docs.travis-ci.com/user/migrating-from-legacy/).