### PR TITLE
Bugfix - PHP 7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ php:
 
 matrix:
   allow_failures:
-    - php: 7.0
     - php: nightly
     - php: hhvm
   fast_finish: true

--- a/tests/Klein/Tests/Mocks/TestClass.php
+++ b/tests/Klein/Tests/Mocks/TestClass.php
@@ -14,7 +14,7 @@ namespace Klein\Tests\Mocks;
 class TestClass
 {
 
-    public static function get($r, $r, $a)
+    public static function get($request, $response, $app)
     {
         echo 'ok';
     }

--- a/tests/Klein/Tests/RoutingTest.php
+++ b/tests/Klein/Tests/RoutingTest.php
@@ -113,20 +113,20 @@ class RoutingTest extends AbstractKleinTest
 
         $this->klein_app->respond(
             '/',
-            function ($r, $r, $s, $a) {
-                $a->state = 'a';
+            function ($request, $response, $service, $app) {
+                $app->state = 'a';
             }
         );
         $this->klein_app->respond(
             '/',
-            function ($r, $r, $s, $a) {
-                $a->state .= 'b';
+            function ($request, $response, $service, $app) {
+                $app->state .= 'b';
             }
         );
         $this->klein_app->respond(
             '/',
-            function ($r, $r, $s, $a) {
-                print $a->state;
+            function ($request, $response, $service, $app) {
+                print $app->state;
             }
         );
 


### PR DESCRIPTION
PHP 7! It lives! It works!

This quick PR simply fixes some compilation/syntax errors in a few tests to comply with the newer, more strict PHP 7 parser.