### PR TITLE
fix REQUEST_URI decode for other language

### DIFF
--- a/src/Klein/Request.php
+++ b/src/Klein/Request.php
@@ -5,7 +5,7 @@
  * @author      Chris O'Hara <cohara87@gmail.com>
  * @author      Trevor Suarez (Rican7) (contributor and v2 refactorer)
  * @copyright   (c) Chris O'Hara
- * @link        https://github.com/chriso/klein.php
+ * @link        https://github.com/klein/klein.php
  * @license     MIT
  */
 
@@ -400,7 +400,7 @@ class Request
      */
     public function uri()
     {
-        return $this->server->get('REQUEST_URI', '/');
+        return urldecode($this->server->get('REQUEST_URI', '/'));
     }
 
     /**


### PR DESCRIPTION
https://exp.com/แผนผังเว็บไซต์   for thai language

is REQUEST_URI = %E0%B9%81%E0%B8%9C%E0%B8%99%E0%B8%9C%E0%B8%B1%E0%B8%87%E0%B9%80%E0%B8%A7%E0%B9%87%E0%B8%9A%E0%B9%84%E0%B8%8B%E0%B8%95%E0%B9%8C

Check the math on the url, it can not be verified.

I used urldecode to solve issue

