### PR TITLE
Bugfix - PHP 7 exception handling compatibility

### DIFF
--- a/src/Klein/Exceptions/RoutePathCompilationException.php
+++ b/src/Klein/Exceptions/RoutePathCompilationException.php
@@ -14,6 +14,7 @@ namespace Klein\Exceptions;
 use Exception;
 use Klein\Route;
 use RuntimeException;
+use Throwable;
 
 /**
  * RoutePathCompilationException
@@ -62,11 +63,14 @@ class RoutePathCompilationException extends RuntimeException implements KleinExc
      * Create a RoutePathCompilationException from a route
      * and an optional previous exception
      *
+     * TODO: Change the `$previous` parameter to type-hint against `Throwable`
+     * once PHP 5.x support is no longer necessary.
+     *
      * @param Route $route          The route that failed to compile
-     * @param Exception $previous   The previous exception
+     * @param Exception|Throwable $previous   The previous exception
      * @return RoutePathCompilationException
      */
-    public static function createFromRoute(Route $route, Exception $previous = null)
+    public static function createFromRoute(Route $route, $previous = null)
     {
         $error = (null !== $previous) ? $previous->getMessage() : null;
         $code  = (null !== $previous) ? $previous->getCode() : null;

--- a/src/Klein/Klein.php
+++ b/src/Klein/Klein.php
@@ -23,6 +23,7 @@ use Klein\Exceptions\UnhandledException;
 use OutOfBoundsException;
 use SplQueue;
 use SplStack;
+use Throwable;
 
 /**
  * Klein
@@ -640,7 +641,9 @@ class Klein
                 $this->response->unlock();
             }
 
-        } catch (Exception $e) {
+        } catch (Throwable $e) { // PHP 7 compatibility
+            $this->error($e);
+        } catch (Exception $e) { // TODO: Remove this catch block once PHP 5.x support is no longer necessary.
             $this->error($e);
         }
 
@@ -909,11 +912,14 @@ class Klein
     /**
      * Routes an exception through the error callbacks
      *
-     * @param Exception $err        The exception that occurred
-     * @throws UnhandledException   If the error/exception isn't handled by an error callback
+     * TODO: Change the `$err` parameter to type-hint against `Throwable` once
+     * PHP 5.x support is no longer necessary.
+     *
+     * @param Exception|Throwable $err The exception that occurred
+     * @throws UnhandledException      If the error/exception isn't handled by an error callback
      * @return void
      */
-    protected function error(Exception $err)
+    protected function error($err)
     {
         $type = get_class($err);
         $msg = $err->getMessage();
@@ -947,7 +953,14 @@ class Klein
 
                 throw new UnhandledException($msg, $err->getCode(), $err);
             }
-        } catch (Exception $e) {
+        } catch (Throwable $e) { // PHP 7 compatibility
+            // Make sure to clean the output buffer before bailing
+            while (ob_get_level() >= $this->output_buffer_level) {
+                ob_end_clean();
+            }
+
+            throw $e;
+        } catch (Exception $e) { // TODO: Remove this catch block once PHP 5.x support is no longer necessary.
             // Make sure to clean the output buffer before bailing
             while (ob_get_level() >= $this->output_buffer_level) {
                 ob_end_clean();
@@ -1050,7 +1063,9 @@ class Klein
                     }
                 }
             }
-        } catch (Exception $e) {
+        } catch (Throwable $e) { // PHP 7 compatibility
+            $this->error($e);
+        } catch (Exception $e) { // TODO: Remove this catch block once PHP 5.x support is no longer necessary.
             $this->error($e);
         }
     }

--- a/tests/Klein/Tests/RoutingTest.php
+++ b/tests/Klein/Tests/RoutingTest.php
@@ -11,6 +11,7 @@
 
 namespace Klein\Tests;
 
+use Exception;
 use Klein\App;
 use Klein\DataCollection\RouteCollection;
 use Klein\Exceptions\DispatchHaltedException;
@@ -2261,7 +2262,7 @@ class RoutingTest extends AbstractKleinTest
             $this->klein_app->dispatch(
                 MockRequestFactory::create('/users/1738197/friends/7828316')
             );
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $exception = $e->getPrevious();
         }
 


### PR DESCRIPTION
This PR updates the way that Klein handles exceptions, for a more full PHP 7 compatibility.

[Exception handling is one of the biggest backwards-incompatible changes made in the major release of PHP 7][php-7-migration-error-handling], as far as code paths (rather than just syntax) goes. The previous update made for PHP 7 compatibility (#342) handled some of the small syntax changes required, while this PR handles the logical changes necessary to enjoy full PHP 7 error/exception handling compatibility. 😃 


[php-7-migration-error-handling]: (http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.error-handling)