### PR TITLE
Dont call onHttpError if ->skipRemaining() is called

### DIFF
--- a/src/Klein/Klein.php
+++ b/src/Klein/Klein.php
@@ -569,6 +569,10 @@ class Klein
                 }
 
                 if (isset($match) && $match ^ $negate) {
+
+                    // Check if need break the loop 
+                    $break = false;
+
                     if ($possible_match) {
                         if (!empty($params)) {
                             /**
@@ -596,7 +600,8 @@ class Klein
                                     $skip_num = $e->getNumberOfSkips();
                                     break;
                                 case DispatchHaltedException::SKIP_REMAINING:
-                                    break 2;
+                                    $break = true;
+                                    break;
                                 default:
                                     throw $e;
                             }
@@ -613,6 +618,11 @@ class Klein
                         $methods_matched = array_merge($methods_matched, (array) $method);
                         $methods_matched = array_filter($methods_matched);
                         $methods_matched = array_unique($methods_matched);
+                    }
+
+                    // Only break after add route to $mathed collection to avoid onHttpError call if throw a SKIP_REMAINING exception 
+                    if($break){
+                        break;
                     }
                 }
             }

--- a/src/Klein/Klein.php
+++ b/src/Klein/Klein.php
@@ -570,7 +570,7 @@ class Klein
 
                 if (isset($match) && $match ^ $negate) {
 
-                    // Check if need break the loop 
+                    // Check if need break the loop
                     $break = false;
 
                     if ($possible_match) {
@@ -620,8 +620,11 @@ class Klein
                         $methods_matched = array_unique($methods_matched);
                     }
 
-                    // Only break after add route to $mathed collection to avoid onHttpError call if throw a SKIP_REMAINING exception 
-                    if($break){
+                    /**
+                     * Only break after add route to $mathed collection to avoid
+                     * onHttpError call if throw a SKIP_REMAINING exception
+                     */
+                    if ($break) {
                         break;
                     }
                 }

--- a/tests/Klein/Tests/RoutingTest.php
+++ b/tests/Klein/Tests/RoutingTest.php
@@ -1088,7 +1088,7 @@ class RoutingTest extends AbstractKleinTest
                 echo 'keep1';
             }
         );
-
+        
         $this->klein_app->respond(
             'GET',
             '/keepNextRequest',
@@ -1097,7 +1097,7 @@ class RoutingTest extends AbstractKleinTest
             }
         );
 
-         $this->klein_app->respond(
+        $this->klein_app->respond(
             'GET',
             '/stopNextRequest',
             function ($request, $response, $service, $app, $klein) {


### PR DESCRIPTION
If you have two equal routers and want skip klein using `skipRemaining` and have `onHttpError` callback, the `onHttpError` callback is called.

This merge request fix this