### PR TITLE
Fixed keys( ) , all( ) function ("magical" call )

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 
 language: php
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -11,6 +10,9 @@ php:
   - hhvm
 
 matrix:
+  include:
+    - php: 5.3
+      dist: precise
   allow_failures:
     - php: nightly
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ php:
   - hhvm
 
 matrix:
-  include:
-    - php: 5.3
-      dist: precise
   allow_failures:
     - php: nightly
     - php: hhvm

--- a/src/Klein/DataCollection/DataCollection.php
+++ b/src/Klein/DataCollection/DataCollection.php
@@ -71,6 +71,12 @@ class DataCollection implements IteratorAggregate, ArrayAccess, Countable
             // Support a more "magical" call
             if (!is_array($mask)) {
                 $mask = func_get_args();
+                $arglen=count($mask);
+                if($mask[$arglen-1]===false || $mask[$arglen-1]===true)
+                  {
+                    $fill_with_nulls=$mask[$arglen-1];
+                    array_pop($mask);
+                  }
             }
 
             /*
@@ -113,6 +119,12 @@ class DataCollection implements IteratorAggregate, ArrayAccess, Countable
             // Support a more "magical" call
             if (!is_array($mask)) {
                 $mask = func_get_args();
+                $arglen=count($mask);
+                if($mask[$arglen-1]===false || $mask[$arglen-1]===true)
+                  {
+                    $fill_with_nulls=$mask[$arglen-1];
+                    array_pop($mask);
+                  }
             }
 
             /*


### PR DESCRIPTION
Previously "magical" call version of the functions 'keys' , 'all' would break as the call : 
        keys( "key1" , "key2" , "key3" , false );
 would result in $mask = ( "key1" , "key2" , "key3" , false ) whereas $fill_with_nulls = "key2" (ultimately translating to true) thus breaking the intended function call which is $mask = ( "key1" , "key2" , "key3" ) and $fill_with_nulls = false

Same is applicable for the function 'all'